### PR TITLE
lower the requirement of node 0.12 so as to support node 0.10.x

### DIFF
--- a/tasks/plantuml.js
+++ b/tasks/plantuml.js
@@ -66,7 +66,7 @@ module.exports = function (grunt) {
                 // If the destination is a directory, use the source file name
                 // with the target image format as extension
                 var dest = single ? file.dest : path.join(file.dest,
-                      path.parse(src).name + '.' + extension),
+                      path.base(src, path.extname(src)) + '.' + extension),
                     dir = path.dirname(dest);
                 grunt.file.mkdir(dir);
                 return processDiagram(src, dest, options);


### PR DESCRIPTION
The requirement to use node 0.12 is [path.parse](https://nodejs.org/api/path.html#path_path_parse_path). However, the line to get file name can be achieved with another two functions combined [path.basename](https://nodejs.org/docs/v0.10.33/api/path.html#path_path_basename_p_ext) and [path.extname](https://nodejs.org/docs/v0.10.33/api/path.html#path_path_extname_p). This replacement lowers the requirement on node versions. 
